### PR TITLE
.travis.yml,CI/travis/after_deploy: trigger other builds after libiio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,3 +137,5 @@ deploy:
     on:
       condition: "$TRAVIS_OS_NAME = osx"
       all_branches: true
+after_deploy:
+  - ${TRAVIS_BUILD_DIR}/CI/travis/after_deploy

--- a/CI/travis/after_deploy
+++ b/CI/travis/after_deploy
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+# These Travis-CI vars have to be non-empty
+[ -n "$TRAVIS_PULL_REQUEST" ] || exit 0
+[ -n "$TRAVIS_BRANCH" ] || exit 0
+[ -n "$ADI_TRAVIS_CI_LIBIIO_TOKEN" ] || exit 0
+
+# Has to be a non-pull-request
+[ "$TRAVIS_PULL_REQUEST" != "false" ] || exit 0
+
+pipeline_branch() {
+	local branch=$1
+
+	# master is a always a pipeline branch
+	[ "$branch" == "master" ] && return 0
+
+	# Check if branch name is 20XX_RY where:
+	#   XX - 14 to 99 /* wooh, that's a lot of years */
+	#   Y  - 1 to 9   /* wooh, that's a lot of releases per year */
+	for year in $(seq 2014 2099) ; do
+		for rel_num in $(seq 1 9) ; do
+			[ "$TRAVIS_BRANCH" == "${year}_R${rel_num}" ] && \
+				return 0
+		done
+	done
+
+	return 1
+}
+
+# Check if it's a pipeline branch; exit otherwise
+pipeline_branch "$TRAVIS_BRANCH" || exit 0
+
+body="{
+	\"request\": {
+		\"branch\":\"$TRAVIS_BRANCH\"
+	}
+}"
+
+curl -s -X POST \
+	-H "Content-Type: application/json" \
+	-H "Accept: application/json" \
+	-H "Travis-API-Version: 3" \
+	-H "Authorization: token $ADI_TRAVIS_CI_LIBIIO_TOKEN" \
+	-d "$body" \
+	https://api.travis-ci.org/repo/analogdevicesinc%2Flibad9361-iio/requests
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -149,3 +149,5 @@ build_script:
     - copy c:\projects\libiio\CI\travis\zip.txt c:\%ARCHIVE_NAME%\README.txt
     - 7z a "c:\libiio.zip" c:\%ARCHIVE_NAME%
     - appveyor PushArtifact c:\libiio.zip
+after_deploy:
+    - curl -H "Authorization: Bearer $APPVEYOR_TOKEN" -H "Content-Type: application/json" https://ci.appveyor.com/api/roles


### PR DESCRIPTION
Let's start a "pipeline", where the libiio build triggers a
`libad9361-iio`, which will trigger other builds as well.

We're getting to a point where the lack of automation is starting to hinder
us a bit and changing things in `libiio` are not visible along the way,
until it gets a bit late.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>